### PR TITLE
Fix SVM Model Training to Correct Dataset Usage

### DIFF
--- a/AI_Workshop_Day1.ipynb
+++ b/AI_Workshop_Day1.ipynb
@@ -891,7 +891,7 @@
         "\n",
         "# model building \n",
         "clf = svm.SVC()\n",
-        "clf.fit(X, y)\n",
+        "clf.fit(X_train, y_train)\n",
         "\n",
         "#Predict the response for test dataset\n",
         "y_pred = clf.predict(X_test)\n",


### PR DESCRIPTION
This pull request updates the SVM model training code to use only the training subset of the data `clf.fit(X_train, y_train)` instead of the entire dataset `clf.fit(X, y)`.